### PR TITLE
Improve 乾/干 conversions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,10 @@ mod tests {
                 "hello world！this is a 非常特殊的企畫。",
                 "hello world！this is a 非常特殊的企划。",
             );
+            map.insert(
+                "乾隆的乾兒子一邊乾淨利落地擲出了一個乾卦，一邊嘴裡嚼着芒果乾。",
+                "乾隆的干儿子一边干净利落地掷出了一个乾卦，一边嘴里嚼着芒果干。",
+            );
             map
         };
     }

--- a/src/special.rs
+++ b/src/special.rs
@@ -25,7 +25,8 @@ lazy_static! {
             '瞭' => hashset!{['瞭','望']},
             '麽' => hashset!{['幺','麽']},
             '幺' => hashset!{['幺','麽']},
-            '於' => hashset!{['樊','於']}
+            '於' => hashset!{['樊','於']},
+            '乾' => hashset!{['乾','隆'], ['乾', '坤'], ['乾', '卦']}
         }
     };
     // Traditional Chinese -> Special convert cases ( only convert in certain case )
@@ -35,7 +36,6 @@ lazy_static! {
             '藉' => hashmap!{['藉','口'] => '借', ['憑','藉'] => '借'},
             '著' => hashmap!{['看','著'] => '着'},
             '苧' => hashmap!{['苧','麻'] => '苎'},
-            '乾' => hashmap!{['乾','燥'] => '干', ['乾','爹'] => '干', ['餅','乾'] => '干', ['乾','枯'] => '干', ['乾','旱'] => '干'},
             // convert these chars use naive mapping if not in special cases
             '闔' => hashmap!{['闔','家'] => '合'},
             '鍾' => hashmap!{['鍾','書'] => '锺'},


### PR DESCRIPTION
There are only a few cases where 乾 should not be converted to 干. Hence, I moved the rule to T2S_EXCLUDE.
Here's a full list of words containing 乾 pronounced as qián from [OpenCC/STPhrases.txt](https://github.com/BYVoid/OpenCC/blob/master/data/dictionary/STPhrases.txt):
```
乾元	乾元
乾兌	乾兌
乾卦	乾卦
乾坤一掷	乾坤一擲
乾坤再造	乾坤再造
乾坤大挪移	乾坤大挪移
乾尽午中	乾盡午中
乾象历	乾象曆
乾隆	乾隆
乾隆年间	乾隆年間
乾隆皇帝	乾隆皇帝
```
I added the three most used words: 乾隆, 乾坤, and 乾卦